### PR TITLE
Add test for serializing proto with sub-type

### DIFF
--- a/e2e/typescript_proto_usage/greeting.proto
+++ b/e2e/typescript_proto_usage/greeting.proto
@@ -1,51 +1,63 @@
 syntax = "proto3";
 
-package com.example.greeting.v1;
+package com.example.greeting.v3;
 
 import "github.com/gonzojive/rules_ts_proto/example/prefix/location/location.proto";
 
 option java_multiple_files = true;
 
 message GreetingRequest {
-    string name = 1;
-    .someorg.type.Position origin = 2;
+  string name = 1;
+  .someorg.type.Position origin = 2;
 
-    message Greeting {
-        string message = 1;
-    }
-    Greeting greeting_message = 3;
+  message Greeting {
+    int32 unimportant_field = 1;
+    string message = 5;
+  }
+  Greeting greeting_message = 3;
 }
 
 message GreetingResponse {
-    string greeting = 1;
+  string greeting = 1;
 }
 
 service GreetingService {
-    rpc greet(GreetingRequest) returns (GreetingResponse);
+  rpc greet(GreetingRequest) returns (GreetingResponse);
 }
 
 enum TopLevelEnumExample {
-    EXAMPLE_ENUM_VALUE_1 = 0;
-    THINGY2 = 2;
+  EXAMPLE_ENUM_VALUE_1 = 0;
+  THINGY2 = 2;
 }
 
 message Foo {
-    message Bar {}
+  message Bar {}
 }
 
 message RepeatedThing {
-    repeated string child_strings = 1;
+  repeated string child_strings = 1;
 
-    repeated .someorg.type.Position child_positions = 2;
+  repeated .someorg.type.Position child_positions = 2;
 
-    repeated GreetingRequest child_requests = 3;
-    repeated TopLevelEnumExample child_enums = 4;
-    repeated Foo.Bar child_bars = 5;
+  repeated GreetingRequest child_requests = 3;
+  repeated TopLevelEnumExample child_enums = 4;
+  repeated Foo.Bar child_bars = 5;
 }
 
 message MutuallyExclusiveThing {
-    oneof some_value {
-        string mutex_string = 1;
-        .someorg.type.Position mutex_position = 2;
+  oneof some_value {
+    string mutex_string = 1;
+    .someorg.type.Position mutex_position = 2;
+  }
+}
+
+message Ancestor1 {
+  message Ancestor2 {
+    message Ancestor3 {
+      int32 ignored1 = 1;
+      int32 ignored2 = 2;
+      int32 ignored3 = 3;
+      string value = 4;
     }
+  }
 }

--- a/e2e/typescript_proto_usage/greeting.proto
+++ b/e2e/typescript_proto_usage/greeting.proto
@@ -9,6 +9,11 @@ option java_multiple_files = true;
 message GreetingRequest {
     string name = 1;
     .someorg.type.Position origin = 2;
+
+    message Greeting {
+        string message = 1;
+    }
+    Greeting greeting_message = 3;
 }
 
 message GreetingResponse {

--- a/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
+++ b/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
@@ -17,6 +17,13 @@ describe("lib", () => {
     expect(requestRoundtripped.getName()).toBe("hello");
   });
 
+  it("sub types should be serializable", () => {
+    const latitude = 42;
+    const request = new GreetingRequest().setOrigin(new Position().setLatitude(latitude));
+    const requestRoundtripped = GreetingRequest.deserializeBinary(request.serializeBinary());
+    expect(requestRoundtripped.getPosition().getLatitude()).toBe(latitude);
+  });
+
   it("should be serializable with repeated fields", () => {
     const object = new RepeatedThing().setChildStringsList(["x", "y"]);
     const roundtripped = RepeatedThing.deserializeBinary(object.serializeBinary());

--- a/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
+++ b/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
@@ -19,9 +19,13 @@ describe("lib", () => {
 
   it("sub types should be serializable", () => {
     const latitude = 42;
-    const request = new GreetingRequest().setOrigin(new Position().setLatitude(latitude));
+    const message = 'hello';
+    const request = new GreetingRequest()
+        .setOrigin(new Position().setLatitude(latitude))
+        .setGreetingMessage(new GreetingRequest.Greeting().setMessage(message));
     const requestRoundtripped = GreetingRequest.deserializeBinary(request.serializeBinary());
-    expect(requestRoundtripped.getPosition().getLatitude()).toBe(latitude);
+    expect(requestRoundtripped.getOrigin().getLatitude()).toBe(latitude);
+    expect(requestRoundtripped.getGreetingMessage().getMessage()).toBe(message);
   });
 
   it("should be serializable with repeated fields", () => {

--- a/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
+++ b/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
@@ -1,4 +1,4 @@
-import { GreetingRequest, TopLevelEnumExample, RepeatedThing } from "../../greeting_pb.mjs"
+import { Ancestor1, GreetingRequest, TopLevelEnumExample, RepeatedThing } from "../../greeting_pb.mjs"
 import { Position } from "../../location/location_pb.mjs"
 //import { GreetingRequest } from "../../greeting_pb";
 
@@ -26,6 +26,15 @@ describe("lib", () => {
     const requestRoundtripped = GreetingRequest.deserializeBinary(request.serializeBinary());
     expect(requestRoundtripped.getOrigin().getLatitude()).toBe(latitude);
     expect(requestRoundtripped.getGreetingMessage().getMessage()).toBe(message);
+  });
+
+  it("sub-sub types should be serializable", () => {
+    const input = new Ancestor1.Ancestor2.Ancestor3()
+        .setValue("xyz");
+    const inputRoundtripped = Ancestor1.Ancestor2.Ancestor3.deserializeBinary(
+      input.serializeBinary());
+    expect(input.getValue()).toBe("xyz");
+    expect(inputRoundtripped.getValue()).toBe("xyz");
   });
 
   it("should be serializable with repeated fields", () => {

--- a/ts_proto/repositories.bzl
+++ b/ts_proto/repositories.bzl
@@ -45,7 +45,7 @@ def rules_ts_proto_dependencies():
 
     git_repository(
         name = "com_google_protobuf_javascript",
-        commit = "dfa5a70a44926f183bdf4fd001dcca869a4f4ad6",
+        commit = "d3ce92c081bd585dc6079609a868744b5e3033fe",
         remote = "https://github.com/gonzojive/protobuf-javascript.git",
     )
 


### PR DESCRIPTION
The test failed before changes to the protobuf-javascript library. Those changes are now part of this PR, and the test no longer fails.

Result:
```
Failures:
1) lib sub types should be serializable
  Message:
    TypeError: message.getName is not a function
```

generated proto serialize and deserialize methods contains incorrect lines:
```
static serializeBinaryToWriter(message, writer) {
    var f = undefined;
    ...
    f = message.getGreetingMessage();
    if (f != null) {
      writer.writeMessage(
        3,
        f,
        GreetingRequest.serializeBinaryToWriter
      );
    }
  }
```

```
static deserializeBinaryFromReader(msg, reader) {
    while (reader.nextField()) {
      if (reader.isEndGroup()) {
        break;
      }
      var field = reader.getFieldNumber();
      ...
      case 3:
        var value = new GreetingRequest;
        reader.readMessage(value,GreetingRequest.deserializeBinaryFromReader);
        msg.setGreetingMessage(value);
        break;
      default:
        reader.skipField();
        break;
      }
    }
    return msg;
  }
```

it should `GreetingRequest.Greeting`