### PR TITLE
Update protobuf-javascript, and add tests for oneofs

### DIFF
--- a/e2e/typescript_proto_usage/greeting.proto
+++ b/e2e/typescript_proto_usage/greeting.proto
@@ -49,6 +49,15 @@ message MutuallyExclusiveThing {
     string mutex_string = 1;
     .someorg.type.Position mutex_position = 2;
   }
+
+  message NestedThing {
+    oneof some_value {
+      string mutex_string = 1;
+      .someorg.type.Position mutex_position = 2;
+    }
+  }
+
+  NestedThing the_thing = 3;
 }
 
 message Ancestor1 {

--- a/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
+++ b/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
@@ -1,4 +1,4 @@
-import { Ancestor1, GreetingRequest, TopLevelEnumExample, RepeatedThing } from "../../greeting_pb.mjs"
+import { Ancestor1, GreetingRequest, TopLevelEnumExample, RepeatedThing, MutuallyExclusiveThing } from "../../greeting_pb.mjs"
 import { Position } from "../../location/location_pb.mjs"
 //import { GreetingRequest } from "../../greeting_pb";
 
@@ -53,6 +53,11 @@ describe("lib", () => {
     const b = new Position().setLatitude(43);
     const thing = new RepeatedThing().setChildPositionsList([a, b]);
     expect(thing.getChildPositionsList().map(x => x.getLatitude())).toEqual([42, 43]);
+  });
+
+  it("should return correct oneof case", () => {
+    const thing = new MutuallyExclusiveThing().setMutexString("test");
+    expect(thing.getSomeValueCase()).toEqual(1);
   });
 });
 

--- a/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
+++ b/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
@@ -60,7 +60,7 @@ describe("lib", () => {
     expect(thing.getSomeValueCase()).toEqual(1);
   });
 
-  it("should return correct onof case for nested message", () => {
+  it("should return correct oneof case for nested message", () => {
     const thing = new MutuallyExclusiveThing()
         .setTheThing(new MutuallyExclusiveThing.NestedThing().setMutexString("test"));
     expect(thing.getTheThing().getSomeValueCase()).toEqual(1);

--- a/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
+++ b/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
@@ -65,6 +65,22 @@ describe("lib", () => {
         .setTheThing(new MutuallyExclusiveThing.NestedThing().setMutexString("test"));
     expect(thing.getTheThing().getSomeValueCase()).toEqual(1);
   });
+
+  it("should clear field", () => {
+    const message = new GreetingRequest().setOrigin(new Position());
+    expect(message.getOrigin()).not.toBeUndefined();
+
+    message.clearOrigin();
+    expect(message.getOrigin()).toBeUndefined();
+  });
+
+  it("should be able to check if value set", () => {
+    const message = new GreetingRequest();
+    expect(message.hasOrigin()).toBe(false);
+
+    message.setOrigin(new Position());
+    expect(message.hasOrigin()).toBe(true);
+  })
 });
 
 describe("TopLevelEnumExample", () => {

--- a/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
+++ b/e2e/typescript_proto_usage/tests/greeting_jasmine/greeting.spec.js
@@ -59,6 +59,12 @@ describe("lib", () => {
     const thing = new MutuallyExclusiveThing().setMutexString("test");
     expect(thing.getSomeValueCase()).toEqual(1);
   });
+
+  it("should return correct onof case for nested message", () => {
+    const thing = new MutuallyExclusiveThing()
+        .setTheThing(new MutuallyExclusiveThing.NestedThing().setMutexString("test"));
+    expect(thing.getTheThing().getSomeValueCase()).toEqual(1);
+  });
 });
 
 describe("TopLevelEnumExample", () => {

--- a/ts_proto/repositories.bzl
+++ b/ts_proto/repositories.bzl
@@ -45,7 +45,7 @@ def rules_ts_proto_dependencies():
 
     git_repository(
         name = "com_google_protobuf_javascript",
-        commit = "d3ce92c081bd585dc6079609a868744b5e3033fe",
+        commit = "885b9cdad5acc46d67f3850155d34226e2b4ee8b",
         remote = "https://github.com/gonzojive/protobuf-javascript.git",
     )
 


### PR DESCRIPTION
```
Failures:
1) lib should return correct oneof case
  Message:
    ReferenceError: proto is not defined
```
which is reffered to
```
  /**
   * @return {proto.com.example.greeting.v3.MutuallyExclusiveThing.SomeValueCase}
   */
  getSomeValueCase() {
    return /** @type {proto.com.example.greeting.v3.MutuallyExclusiveThing.SomeValueCase} */(jspb.Message.computeOneofCase(this, proto.com.example.greeting.v3.MutuallyExclusiveThing.oneofGroups_[0]));
  }
```