### PR TITLE
Remove unused proto_plugin targets.

### DIFF
--- a/ts_proto/codegen/BUILD.bazel
+++ b/ts_proto/codegen/BUILD.bazel
@@ -6,55 +6,6 @@ _ts_proto_gen_bin_factories.protoc_gen_ts_binary(
     visibility = ["//visibility:public"],
 )
 
-# Official Google plugin for generating JavaScript... with some heavy
-# modifications to support ES6 modules.
-proto_plugin(
-    name = "google_js_plugin",
-    exclusions = [
-        "google/protobuf",
-    ],
-    options = [
-        "import_style=es6",
-        "binary",
-    ],
-    outputs = ["{protopath}_pb.js"],
-    tool = "@com_google_protobuf_javascript//generator:protoc-gen-js",
-    visibility = ["//visibility:public"],
-)
-
-# Plugin that generates type definitions for the google_js_plugin.
-proto_plugin(
-    name = "ts_protoc_gen_plugin",
-    env = {
-        "BAZEL_BINDIR": "{bindir}",
-    },
-    options = [
-        # "import_style=commonjs",
-        # "binary",
-    ],
-    outputs = ["{protopath}_pb.d.ts"],
-    tool = ":protoc-gen-ts",
-    use_built_in_shell_environment = False,
-    visibility = ["//visibility:public"],
-)
-
-# grpc-web
-proto_plugin(
-    name = "com_github_grpc_grpc_web",
-    # Used if the output of the generator is empty.
-    # empty_template = "com_github_grpc_grpc_web_empty.js",
-    options = [
-        "import_style=commonjs+dts",
-        "mode=grpcweb",
-    ],
-    outputs = [
-        "{protopath}_grpc_web_pb.js",
-        "{protopath}_grpc_web_pb.d.ts",
-    ],
-    tool = "@com_github_grpc_grpc_web//javascript/net/grpc/web/generator:protoc-gen-grpc-web",
-    visibility = ["//visibility:public"],
-)
-
 proto_plugin(
     name = "delegating_plugin",
     env = {
@@ -64,8 +15,6 @@ proto_plugin(
     outputs = [
         "{protopath}_pb.mjs",
         "{protopath}_pb.d.mts",
-        #"{protopath}_grpc_web_pb.js",
-        #"{protopath}_grpc_web_pb.d.ts",
         "{protopath}_grpc_web_pb.mts",
     ],
     tool = "//ts_proto/codegen/protoc_plugin",


### PR DESCRIPTION
//ts_proto/codegen:delegating_plugin is the only plugin supported by this bazel library. Deleting the others clarifies this.